### PR TITLE
package.json: move '@babel/core' to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "release": "npm run test && npm run build && npm publish"
   },
   "dependencies": {
+    "@babel/core": "^7.7.4",
     "autoprefixer": "^9.7.3",
     "babel-loader": "^8.0.6",
     "case-sensitive-paths-webpack-plugin": "^2.2.0",
@@ -63,7 +64,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",
-    "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-typescript": "^7.7.4",
     "@types/jest": "^24.0.23",


### PR DESCRIPTION
If the project installed as an npm package to the fresh application - there is a problem when running webpack with dependency resolving: `@babel/core`.
So, it can be solved with move the '@babel/core' from 'devDependencies' to 'dependencies'.
BTW. There is another approach - add it to the 'peerDependency'.